### PR TITLE
Simple HTTP Led Control

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,7 +1,27 @@
 # Defines the routes for the Flask web server
 
 from app import app
+from utils.led_control import led_on, led_off, led_default
 
 @app.route('/')
 def home():
+    # Home route for displaying a hello world statement
     return "Hello world! Flask is running on the Raspberry Pi 3."
+
+@app.route('/led/on')
+def turn_led_on():
+    # LED On route for turning the ACT LED on using the led_control
+    led_on()
+    return "LED has been turned on!"
+
+@app.route('/led/off')
+def turn_led_off():
+    # LED Off route for turning the ACT LED off using the led_control
+    led_off()
+    return "LED has been turned off!"
+
+@app.route('/led/default')
+def turn_led_default():
+    # LED Default route for turning the ACT LED to the default state using the led_control
+    led_default()
+    return "LED has been turned to it's default state!"

--- a/utils/led_control.py
+++ b/utils/led_control.py
@@ -1,0 +1,27 @@
+# Control interface for the onboard ACT LED
+
+import os
+
+# Command values
+TRIGGER_NONE = "none"
+TRIGGER_MMC0 = "mmc0"
+LED_ON = 1
+LED_OFF = 0
+
+# Command paths
+TRIGGER_PATH = "/sys/class/leds/ACT/trigger"
+BRIGHTNESS_PATH = "/sys/class/leds/ACT/brightness"
+
+def led_on():
+    # Turn the ACT LED on
+    os.system(f'echo "{TRIGGER_NONE}" | sudo tee {TRIGGER_PATH}')
+    os.system(f'echo "{LED_ON}" | sudo tee {BRIGHTNESS_PATH}')
+
+def led_off():
+    # Turn the ACT LED off
+    os.system(f'echo "{TRIGGER_NONE}" | sudo tee {TRIGGER_PATH}')
+    os.system(f'echo "{LED_OFF}" | sudo tee {BRIGHTNESS_PATH}')
+
+def led_default():
+    # Turn the ACT LED to it's default state
+    os.system(f'echo "{TRIGGER_MMC0}" | sudo tee {TRIGGER_PATH}')


### PR DESCRIPTION
Implemented an led control interface to command the ACT LED to turn on, off, or be set back to the default mmc0 tracking state, added new routes for each of the led interface functions to allow remote control of the LED with simple HTTP GET requests